### PR TITLE
Refactor simple_message

### DIFF
--- a/simple_message/CMakeLists.txt
+++ b/simple_message/CMakeLists.txt
@@ -2,23 +2,38 @@ cmake_minimum_required(VERSION 3.5)
 
 project(simple_message)
 
-set(default_build_type "Release")
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
-  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
-      STRING "Choose the type of build." FORCE)
-endif()
-
-set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic")
-set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-
 # Default to C++14
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(industrial_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+
+# Build static libs, to reduce dependency-chaining for industrial_robot_client
+# set(ROS_BUILD_STATIC_LIBS false)
+# set(ROS_BUILD_SHARED_LIBS true)
+
+# The simple_message library is designed to cross compile on Ubuntu
+# and various robot controllers.  This requires conditionally compiling
+# certain functions and headers.  The definition below enables compiling
+# for a ROS node.
+option(ROS "Use ROS" ON)
+option(LINUXSOCKETS "Use linux socket API" ON)
+option(STDIOLOG "Use stdout for logging" ON)
+option(FLATHEADERS "Flat headers" OFF)
+option(MOTOPLUS "Build for MotoPlus" OFF)
+configure_file(${PROJECT_SOURCE_DIR}/include/config.h.in ${PROJECT_BINARY_DIR}/include/config.h)
+
 set(SRC_FILES
+  ${PROJECT_BINARY_DIR}/include/config.h
+
   src/byte_array.cpp
   src/simple_message.cpp
   src/smpl_msg_connection.cpp
@@ -48,8 +63,9 @@ set(SRC_FILES
   src/messages/joint_traj_pt_full_message.cpp
   src/messages/robot_status_message.cpp
 
-  src/simple_comms_fault_handler.cpp
-)
+  src/simple_comms_fault_handler.cpp)
+
+# set(UTEST_SRC_FILES test/utest.cpp test/utest_message.cpp)
 
 # The simple message make file builds two libraries: simple_message and
 # simple_message_byte_swapping.
@@ -64,52 +80,67 @@ set(SRC_FILES
 # controllers).  This library performs byte swapping at the lowest load/unload
 # levels.
 
-# NOTE: The libraries generated this package are not included in the catkin_package
-# macro because libraries must be explicitly linked in projects that depend on this
-# package.  If this is not done (and these libraries were exported), then multiple
-# library definitions (normal - simple_message and byteswapped - simple_message_bswap)
-# are both included (this is bad).
+include_directories(
+  ${PROJECT_SOURCE_DIR}/include
+  ${PROJECT_BINARY_DIR}/include
+  )
+
+# add_custom_command(
+#   OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_dummy.cpp
+#   COMMAND ${CMAKE_COMMAND} -E touch ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_dummy.cpp)
+# add_library(${PROJECT_NAME}_dummy ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_dummy.cpp)
+
+# unfortunately this will have to be installed, but the linker will remove it
+# from the library dependencies of dependent targets, as it contains no symbols
+# that can be imported from it.
+
+# install(TARGETS ${PROJECT_NAME}_dummy DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+
+# NOTE: All test files require TEST_PORT_BASE to be defined.  Defining different
+# ports for each test executable allows them to run in parallel.
 
 # DEFAULT LIBRARY (SAME ENDIAN)
 add_library(simple_message SHARED ${SRC_FILES})
 
-target_include_directories(simple_message
-  PUBLIC
-    $<INSTALL_INTERFACE:include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-)
-
-# The simple_message library is designed to cross compile on Ubuntu
-# and various robot controllers.  This requires conditionally compiling
-# certain functions and headers.  The definition below enables compiling
-# for a ROS node.
-
-# using std io log
-target_compile_definitions(simple_message PUBLIC -DSTDIOLOG)
-#build using ROS libraries
-target_compile_definitions(simple_message PUBLIC -DROS)
-#use linux sockets for communication
-target_compile_definitions(simple_message PUBLIC -DLINUXSOCKETS)
-
-# find dependencies
-find_package(industrial_msgs REQUIRED)
-find_package(rclcpp REQUIRED)
-
 ament_target_dependencies(simple_message
   industrial_msgs
   rclcpp
-)
+  )
+
+# ALTERNATIVE LIBRARY (DIFFERENT ENDIAN)
+# add_library(simple_message_bswap SHARED ${SRC_FILES})
+# set_target_properties(simple_message_bswap PROPERTIES COMPILE_DEFINITIONS "BYTE_SWAPPING")
+
+# ALTERNATIVE LIBRARY (64-bit floats)
+# add_library(simple_message_float64 ${SRC_FILES})
+# set_target_properties(simple_message_float64 PROPERTIES COMPILE_DEFINITIONS "FLOAT64")
+# target_link_libraries(simple_message_float64 rclcpp)
+# add_dependencies(simple_message_float64 ${industrial_msgs_EXPORTED_TARGETS})
+
+# install(
+#     TARGETS simple_message simple_message_bswap simple_message_float64 
+#     ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#     RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+
+# install(
+#     DIRECTORY include/${PROJECT_NAME}/
+#     DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
 ament_export_libraries(${PROJECT_NAME})
 ament_export_include_directories(include)
 ament_export_dependencies(
   industrial_msgs
-  rclcpp
-)
+  rclcpp)
 
 install(TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION lib)
-install(DIRECTORY include/
+install(DIRECTORY include/simple_message
   DESTINATION include)
+install(FILES
+  ${PROJECT_BINARY_DIR}/include/config.h
+  DESTINATION
+  include
+  )
 
 ament_package()

--- a/simple_message/include/config.h.in
+++ b/simple_message/include/config.h.in
@@ -1,0 +1,10 @@
+#ifndef CONFIG_H_
+#define CONFIG_H_
+
+#cmakedefine ROS
+#cmakedefine LINUXSOCKETS
+#cmakedefine STDIOLOG
+#cmakedefine FLATHEADERS
+#cmakedefine MOTOPLUS
+
+#endif

--- a/simple_message/include/simple_message/byte_array.h
+++ b/simple_message/include/simple_message/byte_array.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2015, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef BYTE_ARRAY_H
 #define BYTE_ARRAY_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/shared_types.h"
@@ -128,7 +130,7 @@ public:
    * \param buffer buffer to copy
    *
    */
-  void copyFrom(ByteArray & buffer);
+  void copyFrom(const ByteArray& buffer);
 
   /**
    * \brief Copy to std::vector, for raw-ptr access
@@ -138,7 +140,7 @@ public:
    * \param out vector to copy into
    *
    */
-  void copyTo(std::vector<char> & out);
+  void copyTo(std::vector<char>& out);
 
   /**
    * \brief loads a boolean into the byte array
@@ -181,7 +183,7 @@ public:
    * \return true on success, false otherwise (max array size exceeded).
    * Value not loaded
    */
-  bool load(industrial::simple_serialize::SimpleSerialize &value);
+  bool load(const industrial::simple_serialize::SimpleSerialize& value);
 
   /**
    * \brief loads a whole byte array into this byte array
@@ -191,7 +193,7 @@ public:
    * \return true on success, false otherwise (max array size exceeded).
    * Value not loaded
    */
-  bool load(ByteArray &value);
+  bool load(const ByteArray& value);
 
   /**
    * \brief loads a void* (treated as char*) into the byte array.
@@ -313,14 +315,14 @@ public:
    *
    * \return buffer size
    */
-  unsigned int getBufferSize();
+  unsigned int getBufferSize() const;
 
   /**
    * \brief gets current buffer size
    *
    * \return buffer size
    */
-  unsigned int getMaxBufferSize();
+  unsigned int getMaxBufferSize() const;
 
   /**
      * \brief returns true if byte swapping is enabled (this is a global
@@ -337,7 +339,7 @@ private:
    * \brief internal data buffer
    */
   std::deque<char> buffer_;
-  
+
   /**
    * \brief temporary continuous buffer for getRawDataPtr() use
    */

--- a/simple_message/include/simple_message/comms_fault_handler.h
+++ b/simple_message/include/simple_message/comms_fault_handler.h
@@ -32,6 +32,8 @@
 #ifndef COMMS_FAULT_HANDLER_H
 #define COMMS_FAULT_HANDLER_H
 
+#include "config.h"
+
 namespace industrial
 {
 namespace comms_fault_handler

--- a/simple_message/include/simple_message/joint_data.h
+++ b/simple_message/include/simple_message/joint_data.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef JOINT_DATA_H
 #define JOINT_DATA_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/simple_message.h"
@@ -122,7 +124,7 @@ public:
    *
    * \param src (value to copy)
    */
-  void copyFrom(JointData &src);
+  void copyFrom(const JointData& src);
 
   /**
    * \brief returns the maximum number of joints the message holds
@@ -139,12 +141,12 @@ public:
    *
    * \return true if equal
    */
-  bool operator==(JointData &rhs);
+  bool operator==(const JointData& rhs) const;
 
   // Overrides - SimpleSerialize
-  bool load(industrial::byte_array::ByteArray *buffer);
+  bool load(industrial::byte_array::ByteArray *buffer) const;
   bool unload(industrial::byte_array::ByteArray *buffer);
-  unsigned int byteLength()
+  unsigned int byteLength() const
   {
     return MAX_NUM_JOINTS * sizeof(industrial::shared_types::shared_real);
   }

--- a/simple_message/include/simple_message/joint_feedback.h
+++ b/simple_message/include/simple_message/joint_feedback.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2013, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef JOINT_FEEDBACK_H
 #define JOINT_FEEDBACK_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/joint_data.h"
@@ -110,9 +112,9 @@ public:
   void init(industrial::shared_types::shared_int robot_id,
             industrial::shared_types::shared_int valid_fields,
             industrial::shared_types::shared_real time,
-            industrial::joint_data::JointData & positions,
-            industrial::joint_data::JointData & velocities,
-            industrial::joint_data::JointData & accelerations);
+            const industrial::joint_data::JointData& positions,
+            const industrial::joint_data::JointData& velocities,
+            const industrial::joint_data::JointData& accelerations);
 
   /**
    * \brief Sets robot_id.
@@ -131,7 +133,7 @@ public:
    *
    * @return robot_id value
    */
-  industrial::shared_types::shared_int getRobotID()
+  industrial::shared_types::shared_int getRobotID() const
   {
     return this->robot_id_;
   }
@@ -153,7 +155,7 @@ public:
    * \param time returned time value
    * \return true if this field contains valid data
    */
-  bool getTime(industrial::shared_types::shared_real & time)
+  bool getTime(industrial::shared_types::shared_real& time) const
   {
     time = this->time_;
     return is_valid(ValidFieldTypes::TIME);
@@ -173,7 +175,7 @@ public:
    *
    * \param positions new joint position data
    */
-  void setPositions(industrial::joint_data::JointData &positions)
+  void setPositions(const industrial::joint_data::JointData& positions)
   {
     this->positions_.copyFrom(positions);
     this->valid_fields_ |= ValidFieldTypes::POSITION;  // set the bit
@@ -185,7 +187,7 @@ public:
    * \param dest returned joint position
    * \return true if this field contains valid data
    */
-  bool getPositions(industrial::joint_data::JointData &dest)
+  bool getPositions(industrial::joint_data::JointData& dest) const
   {
     dest.copyFrom(this->positions_);
     return is_valid(ValidFieldTypes::POSITION);
@@ -205,7 +207,7 @@ public:
    *
    * \param velocities new joint velocity data
    */
-  void setVelocities(industrial::joint_data::JointData &velocities)
+  void setVelocities(const industrial::joint_data::JointData& velocities)
   {
     this->velocities_.copyFrom(velocities);
     this->valid_fields_ |= ValidFieldTypes::VELOCITY;  // set the bit
@@ -217,7 +219,7 @@ public:
    * \param dest returned joint velocity
    * \return true if this field contains valid data
    */
-  bool getVelocities(industrial::joint_data::JointData &dest)
+  bool getVelocities(industrial::joint_data::JointData& dest) const
   {
     dest.copyFrom(this->velocities_);
     return is_valid(ValidFieldTypes::VELOCITY);
@@ -231,12 +233,13 @@ public:
     this->velocities_.init();
     this->valid_fields_ &= ~ValidFieldTypes::VELOCITY;  // clear the bit
   }
+
   /**
    * \brief Sets joint acceleration data
    *
    * \param accelerations new joint acceleration data
    */
-  void setAccelerations(industrial::joint_data::JointData &accelerations)
+  void setAccelerations(const industrial::joint_data::JointData& accelerations)
   {
     this->accelerations_.copyFrom(accelerations);
     this->valid_fields_ |= ValidFieldTypes::ACCELERATION;  // set the bit
@@ -248,7 +251,7 @@ public:
    * \param dest returned joint acceleration
    * \return true if this field contains valid data
    */
-  bool getAccelerations(industrial::joint_data::JointData &dest)
+  bool getAccelerations(industrial::joint_data::JointData& dest) const
   {
     dest.copyFrom(this->accelerations_);
     return is_valid(ValidFieldTypes::ACCELERATION);
@@ -263,35 +266,34 @@ public:
     this->valid_fields_ &= ~ValidFieldTypes::ACCELERATION;  // clear the bit
   }
 
-
   /**
    * \brief Copies the passed in value
    *
    * \param src (value to copy)
    */
-  void copyFrom(JointFeedback &src);
+  void copyFrom(const JointFeedback& src);
 
   /**
    * \brief == operator implementation
    *
    * \return true if equal
    */
-  bool operator==(JointFeedback &rhs);
+  bool operator==(const JointFeedback& rhs) const;
 
   /**
    * \brief check the validity state for a given field
    * @param field field to check
    * @return true if specified field contains valid data
    */
-  bool is_valid(ValidFieldType field)
+  bool is_valid(ValidFieldType field) const
   {
     return valid_fields_ & field;
   }
 
   // Overrides - SimpleSerialize
-  bool load(industrial::byte_array::ByteArray *buffer);
+  bool load(industrial::byte_array::ByteArray *buffer) const;
   bool unload(industrial::byte_array::ByteArray *buffer);
-  unsigned int byteLength()
+  unsigned int byteLength() const
   {
     return 2*sizeof(industrial::shared_types::shared_int) + sizeof(industrial::shared_types::shared_real)
         + 3*this->positions_.byteLength();

--- a/simple_message/include/simple_message/joint_traj.h
+++ b/simple_message/include/simple_message/joint_traj.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef JOINT_TRAJ_H
 #define JOINT_TRAJ_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/simple_message.h"
@@ -70,92 +72,94 @@ namespace joint_traj
 class JointTraj : public industrial::simple_serialize::SimpleSerialize
 {
 public:
-	/**
-	 * \brief Default constructor
-	 *
-	 * This method creates empty data.
-	 *
-	 */
-	JointTraj(void);
-	/**
-	 * \brief Destructor
-	 *
-	 */
-	~JointTraj(void);
+  /**
+   * \brief Default constructor
+   *
+   * This method creates empty data.
+   *
+   */
+  JointTraj(void);
 
-	/**
-	 * \brief Initializes a empty joint data
-	 *
-	 */
-	void init();
+  /**
+   * \brief Destructor
+   *
+   */
+  ~JointTraj(void);
 
-	/**
-	 * \brief Adds a point value to the end of the buffer
-	 *
-	 * \param point value
-	 *
-	 * \return true if value set, otherwise false (buffer is full)
-	 */
-	bool addPoint(industrial::joint_traj_pt::JointTrajPt & point);
+  /**
+   * \brief Initializes a empty joint data
+   *
+   */
+  void init();
 
-	/**
-	 * \brief Gets a point value within the buffer
-	 *
-	 * \param point index
-	 * \param point value
-	 *
-	 * \return true if value set, otherwise false (index greater than size)
-	 */
-	bool getPoint(industrial::shared_types::shared_int index,
-			industrial::joint_traj_pt::JointTrajPt & point);
-	/**
-	 * \brief Gets a size of trajectory
-	 *
-	 * \return trajectory size
-	 */
-	industrial::shared_types::shared_int size()
-	{
-		return this->size_;
-	}
+  /**
+   * \brief Adds a point value to the end of the buffer
+   *
+   * \param point value
+   *
+   * \return true if value set, otherwise false (buffer is full)
+   */
+  bool addPoint(const industrial::joint_traj_pt::JointTrajPt& point);
 
-	/**
-	 * \brief returns True if buffer is full
-	 *
-	 * \return true if buffer is full
-	 */
-	bool isFull()
-	{
-		return this->size_ >= this->getMaxNumPoints();
-	}
+  /**
+   * \brief Gets a point value within the buffer
+   *
+   * \param point index
+   * \param point value
+   *
+   * \return true if value set, otherwise false (index greater than size)
+   */
+  bool getPoint(industrial::shared_types::shared_int index,
+      industrial::joint_traj_pt::JointTrajPt& point) const;
 
-	/**
-	 * \brief returns the maximum number of points the message holds
-	 *
-	 * \return max number of points
-	 */
-	int getMaxNumPoints() const
-	{
-		return MAX_NUM_POINTS;
-	}
+  /**
+   * \brief Gets a size of trajectory
+   *
+   * \return trajectory size
+   */
+  industrial::shared_types::shared_int size() const
+  {
+    return this->size_;
+  }
 
-	/**
-	 * \brief Copies the passed in value
-	 *
-	 * \param src (value to copy)
-	 */
-	void copyFrom(JointTraj &src);
+  /**
+   * \brief returns True if buffer is full
+   *
+   * \return true if buffer is full
+   */
+  bool isFull() const
+  {
+    return this->size_ >= this->getMaxNumPoints();
+  }
 
-	/**
-	 * \brief == operator implementation
-	 *
-	 * \return true if equal
-	 */
-	bool operator==(JointTraj &rhs);
+  /**
+   * \brief returns the maximum number of points the message holds
+   *
+   * \return max number of points
+   */
+  int getMaxNumPoints() const
+  {
+    return MAX_NUM_POINTS;
+  }
+
+  /**
+   * \brief Copies the passed in value
+   *
+   * \param src (value to copy)
+   */
+  void copyFrom(const JointTraj& src);
+
+  /**
+   * \brief == operator implementation
+   *
+   * \return true if equal
+   */
+  bool operator==(const JointTraj& rhs) const;
 
 	// Overrides - SimpleSerialize
-	bool load(industrial::byte_array::ByteArray *buffer);
+	bool load(industrial::byte_array::ByteArray *buffer) const;
 	bool unload(industrial::byte_array::ByteArray *buffer);
-	unsigned int byteLength()
+	unsigned int byteLength() const
 	{
 		industrial::joint_traj_pt::JointTrajPt pt;
 		return this->size() * pt.byteLength();
@@ -164,17 +168,17 @@ public:
 private:
 
 	/**
-	 * \brief maximum number of joints positions that can be held in the message.
-	 */
-	static const industrial::shared_types::shared_int MAX_NUM_POINTS = 200;
-	/**
-	 * \brief internal data buffer
-	 */
-	industrial::joint_traj_pt::JointTrajPt points_[MAX_NUM_POINTS];
-	/**
-	 * \brief size of trajectory
-	 */
-	industrial::shared_types::shared_int size_;
+   * \brief maximum number of joints positions that can be held in the message.
+   */
+  static const industrial::shared_types::shared_int MAX_NUM_POINTS = 200;
+  /**
+   * \brief internal data buffer
+   */
+  industrial::joint_traj_pt::JointTrajPt points_[MAX_NUM_POINTS];
+  /**
+   * \brief size of trajectory
+   */
+  industrial::shared_types::shared_int size_;
 
 };
 

--- a/simple_message/include/simple_message/joint_traj_pt.h
+++ b/simple_message/include/simple_message/joint_traj_pt.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef JOINT_TRAJ_PT_H
 #define JOINT_TRAJ_PT_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/joint_data.h"
@@ -115,7 +117,7 @@ public:
    * \brief Initializes a complete trajectory point
    *
    */
-  void init(industrial::shared_types::shared_int sequence, industrial::joint_data::JointData & position,
+  void init(industrial::shared_types::shared_int sequence, const industrial::joint_data::JointData& position,
             industrial::shared_types::shared_real velocity, industrial::shared_types::shared_real duration);
 
   /**
@@ -123,7 +125,7 @@ public:
    *
    * \param joint position data
    */
-  void setJointPosition(industrial::joint_data::JointData &position)
+  void setJointPosition(const industrial::joint_data::JointData& position)
   {
     this->joint_position_.copyFrom(position);
   }
@@ -133,7 +135,7 @@ public:
    *
    * \param joint position dest
    */
-  void getJointPosition(industrial::joint_data::JointData &dest)
+  void getJointPosition(industrial::joint_data::JointData& dest) const
   {
     dest.copyFrom(this->joint_position_);
   }
@@ -153,7 +155,7 @@ public:
    *
    * \return joint trajectory sequence number
    */
-  industrial::shared_types::shared_int getSequence()
+  industrial::shared_types::shared_int getSequence() const
   {
     return this->sequence_;
   }
@@ -173,49 +175,49 @@ public:
    *
    * \return joint trajectory velocity
    */
-  industrial::shared_types::shared_real getVelocity()
+  industrial::shared_types::shared_real getVelocity() const
   {
     return this->velocity_;
   }
 
   /**
-     * \brief Sets joint trajectory point duration
-     *
-     * \param velocity value
-     */
-    void setDuration(industrial::shared_types::shared_real duration)
-    {
-      this->duration_ = duration;
-    }
+   * \brief Sets joint trajectory point duration
+   *
+   * \param velocity value
+   */
+  void setDuration(industrial::shared_types::shared_real duration)
+  {
+    this->duration_ = duration;
+  }
 
-    /**
-     * \brief Returns joint trajectory point duration
-     *
-     * \return joint trajectory velocity
-     */
-    industrial::shared_types::shared_real getDuration()
-    {
-      return this->duration_;
-    }
+  /**
+   * \brief Returns joint trajectory point duration
+   *
+   * \return joint trajectory velocity
+   */
+  industrial::shared_types::shared_real getDuration() const
+  {
+    return this->duration_;
+  }
 
   /**
    * \brief Copies the passed in value
    *
    * \param src (value to copy)
    */
-  void copyFrom(JointTrajPt &src);
+  void copyFrom(const JointTrajPt& src);
 
   /**
    * \brief == operator implementation
    *
    * \return true if equal
    */
-  bool operator==(JointTrajPt &rhs);
+  bool operator==(const JointTrajPt& rhs) const;
 
   // Overrides - SimpleSerialize
-  bool load(industrial::byte_array::ByteArray *buffer);
+  bool load(industrial::byte_array::ByteArray *buffer) const;
   bool unload(industrial::byte_array::ByteArray *buffer);
-  unsigned int byteLength()
+  unsigned int byteLength() const
   {
     return sizeof(industrial::shared_types::shared_real) + sizeof(industrial::shared_types::shared_int)
         + this->joint_position_.byteLength();

--- a/simple_message/include/simple_message/joint_traj_pt_full.h
+++ b/simple_message/include/simple_message/joint_traj_pt_full.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2013, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef JOINT_TRAJ_PT_FULL_H
 #define JOINT_TRAJ_PT_FULL_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/joint_data.h"
@@ -128,9 +130,9 @@ public:
             industrial::shared_types::shared_int sequence,
             industrial::shared_types::shared_int valid_fields,
             industrial::shared_types::shared_real time,
-            industrial::joint_data::JointData & positions,
-            industrial::joint_data::JointData & velocities,
-            industrial::joint_data::JointData & accelerations);
+            const industrial::joint_data::JointData& positions,
+            const industrial::joint_data::JointData& velocities,
+            const industrial::joint_data::JointData& accelerations);
 
   /**
    * \brief Sets robot_id.
@@ -149,7 +151,7 @@ public:
    *
    * @return robot_id value
    */
-  industrial::shared_types::shared_int getRobotID()
+  industrial::shared_types::shared_int getRobotID() const
   {
     return this->robot_id_;
   }
@@ -169,7 +171,7 @@ public:
    *
    * \return joint trajectory sequence number
    */
-  industrial::shared_types::shared_int getSequence()
+  industrial::shared_types::shared_int getSequence() const
   {
     return this->sequence_;
   }
@@ -191,7 +193,7 @@ public:
    * \param time returned time value
    * \return true if this field contains valid data
    */
-  bool getTime(industrial::shared_types::shared_real & time)
+  bool getTime(industrial::shared_types::shared_real & time) const
   {
     time = this->time_;
     return is_valid(ValidFieldTypes::TIME);
@@ -211,7 +213,7 @@ public:
    *
    * \param positions new joint position data
    */
-  void setPositions(industrial::joint_data::JointData &positions)
+  void setPositions(const industrial::joint_data::JointData& positions)
   {
     this->positions_.copyFrom(positions);
     this->valid_fields_ |= ValidFieldTypes::POSITION;  // set the bit
@@ -223,7 +225,7 @@ public:
    * \param dest returned joint position
    * \return true if this field contains valid data
    */
-  bool getPositions(industrial::joint_data::JointData &dest)
+  bool getPositions(industrial::joint_data::JointData& dest) const
   {
     dest.copyFrom(this->positions_);
     return is_valid(ValidFieldTypes::POSITION);
@@ -243,7 +245,7 @@ public:
    *
    * \param velocities new joint velocity data
    */
-  void setVelocities(industrial::joint_data::JointData &velocities)
+  void setVelocities(const industrial::joint_data::JointData& velocities)
   {
     this->velocities_.copyFrom(velocities);
     this->valid_fields_ |= ValidFieldTypes::VELOCITY;  // set the bit
@@ -255,7 +257,7 @@ public:
    * \param dest returned joint velocity
    * \return true if this field contains valid data
    */
-  bool getVelocities(industrial::joint_data::JointData &dest)
+  bool getVelocities(industrial::joint_data::JointData& dest) const
   {
     dest.copyFrom(this->velocities_);
     return is_valid(ValidFieldTypes::VELOCITY);
@@ -274,7 +276,7 @@ public:
    *
    * \param accelerations new joint acceleration data
    */
-  void setAccelerations(industrial::joint_data::JointData &accelerations)
+  void setAccelerations(const industrial::joint_data::JointData& accelerations)
   {
     this->accelerations_.copyFrom(accelerations);
     this->valid_fields_ |= ValidFieldTypes::ACCELERATION;  // set the bit
@@ -286,7 +288,7 @@ public:
    * \param dest returned joint acceleration
    * \return true if this field contains valid data
    */
-  bool getAccelerations(industrial::joint_data::JointData &dest)
+  bool getAccelerations(industrial::joint_data::JointData& dest) const
   {
     dest.copyFrom(this->accelerations_);
     return is_valid(ValidFieldTypes::ACCELERATION);
@@ -301,35 +303,34 @@ public:
     this->valid_fields_ &= ~ValidFieldTypes::ACCELERATION;  // clear the bit
   }
 
-
   /**
    * \brief Copies the passed in value
    *
    * \param src (value to copy)
    */
-  void copyFrom(JointTrajPtFull &src);
+  void copyFrom(const JointTrajPtFull& src);
 
   /**
    * \brief == operator implementation
    *
    * \return true if equal
    */
-  bool operator==(JointTrajPtFull &rhs);
+  bool operator==(const JointTrajPtFull& rhs) const;
 
   /**
    * \brief check the validity state for a given field
    * @param field field to check
    * @return true if specified field contains valid data
    */
-  bool is_valid(ValidFieldType field)
+  bool is_valid(ValidFieldType field) const
   {
     return valid_fields_ & field;
   }
 
   // Overrides - SimpleSerialize
-  bool load(industrial::byte_array::ByteArray *buffer);
+  bool load(industrial::byte_array::ByteArray *buffer) const;
   bool unload(industrial::byte_array::ByteArray *buffer);
-  unsigned int byteLength()
+  unsigned int byteLength() const
   {
     return 3*sizeof(industrial::shared_types::shared_int) + sizeof(industrial::shared_types::shared_real)
         + 3*this->positions_.byteLength();

--- a/simple_message/include/simple_message/log_wrapper.h
+++ b/simple_message/include/simple_message/log_wrapper.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Software License Agreement (BSD License)
 *
 * Copyright (c) 2011, Southwest Research Institute
@@ -32,6 +32,8 @@
 #ifndef LOG_WRAPPER_H_
 #define LOG_WRAPPER_H_
 
+#include "config.h"
+
 #ifdef ROS
 #include "rclcpp/rclcpp.hpp"
 #endif
@@ -56,8 +58,33 @@ namespace industrial
  */
 namespace log_wrapper
 {
-    
-#ifdef STDIOLOG
+
+
+// Define ROS if this library will execute under ROS
+#ifdef ROS
+
+// The LOG_COMM redirects to debug in ROS because ROS has
+// debug filtering tools that allow the communications messages
+// to be easily removed from the logs
+#define LOG_COMM(format, ...)  \
+  RCLCPP_DEBUG(rclcpp::get_logger("simple_message"), format, ##__VA_ARGS__)
+
+#define LOG_DEBUG(format, ...)  \
+  RCLCPP_DEBUG(rclcpp::get_logger("simple_message"), format, ##__VA_ARGS__)
+
+#define LOG_INFO(format, ...)  \
+  RCLCPP_INFO(rclcpp::get_logger("simple_message"), format, ##__VA_ARGS__)
+
+#define LOG_WARN(format, ...)  \
+  RCLCPP_WARN(rclcpp::get_logger("simple_message"), format, ##__VA_ARGS__)
+
+#define LOG_ERROR(format, ...)  \
+  RCLCPP_ERROR(rclcpp::get_logger("simple_message"), format, ##__VA_ARGS__)
+
+#define LOG_FATAL(format, ...)  \
+  RCLCPP_FATAL(rclcpp::get_logger("simple_message"), format, ##__VA_ARGS__)
+
+#elif defined(STDIOLOG)
 
 #define LOG(level, format, ...) \
 do \
@@ -76,30 +103,6 @@ do \
 #define LOG_WARN(format, ...)  LOG("WARNING", format, ##__VA_ARGS__)
 #define LOG_ERROR(format, ...) LOG("ERROR", format, ##__VA_ARGS__)
 #define LOG_FATAL(format, ...) LOG("FATAL", format, ##__VA_ARGS__)
-
-// Define ROS if this library will execute under ROS
-#elif defined(ROS)
-
-// The LOG_COMM redirects to debug in ROS because ROS has
-// debug filtering tools that allow the communications messages
-// to be easily removed from the logs
-#define LOG_COMM(format, ...)  \
-  RCLCPP_DEBUG(rclcpp::get_logger("simple_message"), format, ##__VA_ARGS__)
-  
-#define LOG_DEBUG(format, ...)  \
-  RCLCPP_DEBUG(rclcpp::get_logger("simple_message"), format, ##__VA_ARGS__)
-
-#define LOG_INFO(format, ...)  \
-  RCLCPP_INFO(rclcpp::get_logger("simple_message"), format, ##__VA_ARGS__)
-
-#define LOG_WARN(format, ...)  \
-  RCLCPP_WARN(rclcpp::get_logger("simple_message"), format, ##__VA_ARGS__)
-
-#define LOG_ERROR(format, ...)  \
-  RCLCPP_ERROR(rclcpp::get_logger("simple_message"), format, ##__VA_ARGS__)
-
-#define LOG_FATAL(format, ...)  \
-  RCLCPP_FATAL(rclcpp::get_logger("simple_message"), FATAL, ##__VA_ARGS__)
 
 #else
 // LOG DISABLED

--- a/simple_message/include/simple_message/message_handler.h
+++ b/simple_message/include/simple_message/message_handler.h
@@ -32,6 +32,8 @@
 #ifndef MESSAGE_HANDLER_H
 #define MESSAGE_HANDLER_H
 
+#include "config.h"
+
 #ifndef FLATHEADERS
 #include "simple_message/simple_message.h"
 #include "simple_message/smpl_msg_connection.h"
@@ -83,18 +85,17 @@ public:
    *
    * \return true on success, false otherwise
    */
-  bool callback(industrial::simple_message::SimpleMessage & in);
+  bool callback(const industrial::simple_message::SimpleMessage& in);
 
   /**
    * \brief Gets message type that callback expects
    *
    * \return message type
    */
-  int getMsgType()
+  int getMsgType() const
   {
     return this->msg_type_;
   }
-  ;
 
 protected:
   /**
@@ -106,7 +107,6 @@ protected:
   {
     return this->connection_;
   }
-  ;
 
   /**
    * \brief Class initializer
@@ -137,7 +137,7 @@ private:
    *
    * \return true on success, false otherwise
    */
-  virtual bool internalCB(industrial::simple_message::SimpleMessage & in)=0;
+  virtual bool internalCB(const industrial::simple_message::SimpleMessage& in) = 0;
 
   /**
    * \brief Validates incoming message for processing by internal callback
@@ -146,7 +146,7 @@ private:
    *
    * \return true on if valid, false otherwise
    */
-  bool validateMsg(industrial::simple_message::SimpleMessage & in);
+  bool validateMsg(const industrial::simple_message::SimpleMessage& in) const;
 
   /**
    * \brief Sets connection for message replies
@@ -157,7 +157,6 @@ private:
   {
     this->connection_ = connection;
   }
-  ;
 
   /**
    * \brief Sets message type that callback expects
@@ -168,7 +167,6 @@ private:
   {
     this->msg_type_ = msg_type;
   }
-  ;
 
 };
 

--- a/simple_message/include/simple_message/message_manager.h
+++ b/simple_message/include/simple_message/message_manager.h
@@ -32,6 +32,8 @@
 #ifndef MESSAGE_MANAGER_H
 #define MESSAGE_MANAGER_H
 
+#include "config.h"
+
 #ifndef FLATHEADERS
 #include "simple_message/smpl_msg_connection.h"
 #include "simple_message/message_handler.h"
@@ -138,7 +140,7 @@ public:
    *
    * \return connection reference
    */
-  unsigned int getNumHandlers()
+  unsigned int getNumHandlers() const
   {
     return this->num_handlers_;
   }
@@ -148,11 +150,10 @@ public:
    *
    * \return connection reference
    */
-  unsigned int getMaxNumHandlers()
+  unsigned int getMaxNumHandlers() const
   {
     return this->MAX_NUM_HANDLERS;
   }
-
 
   /**
    * \brief Gets communications fault handler
@@ -173,7 +174,6 @@ public:
   {
     this->comms_hndlr_ = handler;
   }
-
 
 private:
 
@@ -243,6 +243,7 @@ private:
   {
     return this->def_comms_hndlr_;
   }
+
   /**
    * \brief Gets ping handler
    *
@@ -252,7 +253,6 @@ private:
   {
     return this->ping_hndlr_;
   }
-  ;
 
   /**
    * \brief Sets connection manager
@@ -263,7 +263,6 @@ private:
   {
     this->connection_ = connection;
   }
-  ;
 
   /**
    * \brief Gets connection for manager
@@ -274,7 +273,6 @@ private:
   {
     return this->connection_;
   }
-  ;
 
   /**
    * \brief Sets message type that callback expects
@@ -285,7 +283,6 @@ private:
   {
     this->num_handlers_ = num_handlers;
   }
-  ;
 
 };
 

--- a/simple_message/include/simple_message/messages/joint_feedback_message.h
+++ b/simple_message/include/simple_message/messages/joint_feedback_message.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2013, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef JOINT_FEEDBACK_MESSAGE_H
 #define JOINT_FEEDBACK_MESSAGE_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/typed_message.h"
@@ -85,7 +87,7 @@ public:
    *
    * \return true if message successfully initialized, otherwise false
    */
-  bool init(industrial::simple_message::SimpleMessage & msg);
+  bool init(const industrial::simple_message::SimpleMessage& msg);
 
   /**
    * \brief Initializes message from a joint feedback structure
@@ -93,7 +95,7 @@ public:
    * \param joint feedback data structure
    *
    */
-  void init(industrial::joint_feedback::JointFeedback & data);
+  void init(const industrial::joint_feedback::JointFeedback& data);
 
   /**
    * \brief Initializes a new message
@@ -102,43 +104,40 @@ public:
   void init();
 
   // Overrides - SimpleSerialize
-  bool load(industrial::byte_array::ByteArray *buffer);
+  bool load(industrial::byte_array::ByteArray *buffer) const;
   bool unload(industrial::byte_array::ByteArray *buffer);
 
-  unsigned int byteLength()
+  unsigned int byteLength() const
   {
     return this->data_.byteLength();
   }
 
-  industrial::shared_types::shared_int getRobotID()
+  industrial::shared_types::shared_int getRobotID() const
   {
     return this->data_.getRobotID();
   }
 
-  bool getTime(industrial::shared_types::shared_real & time)
+  bool getTime(industrial::shared_types::shared_real& time) const
   {
     return this->data_.getTime(time);
   }
 
-  bool getPositions(industrial::joint_data::JointData &dest)
+  bool getPositions(industrial::joint_data::JointData& dest) const
   {
     return this->data_.getPositions(dest);
   }
 
-  bool getVelocities(industrial::joint_data::JointData &dest)
+  bool getVelocities(industrial::joint_data::JointData& dest) const
   {
     return this->data_.getVelocities(dest);
   }
 
-  bool getAccelerations(industrial::joint_data::JointData &dest)
+  bool getAccelerations(industrial::joint_data::JointData& dest) const
   {
     return this->data_.getAccelerations(dest);
   }
 
-private:
-
   industrial::joint_feedback::JointFeedback data_;
-
 };
 
 }

--- a/simple_message/include/simple_message/messages/joint_message.h
+++ b/simple_message/include/simple_message/messages/joint_message.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef JOINT_MESSAGE_H
 #define JOINT_MESSAGE_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/typed_message.h"
@@ -104,7 +106,7 @@ public:
    *
    * \return true if message successfully initialized, otherwise false
    */
-  bool init(industrial::simple_message::SimpleMessage & msg);
+  bool init(const industrial::simple_message::SimpleMessage& msg);
 
   /**
    * \brief Initializes message from a joint structure
@@ -113,7 +115,7 @@ public:
    * \param joints
    *
    */
-  void init(industrial::shared_types::shared_int seq, industrial::joint_data::JointData & joints);
+  void init(industrial::shared_types::shared_int seq, const industrial::joint_data::JointData& joints);
 
   /**
    * \brief Initializes a new joint message
@@ -133,7 +135,7 @@ public:
    *
    * \return message sequence number
    */
-  industrial::shared_types::shared_int getSequence()
+  industrial::shared_types::shared_int getSequence() const
   {
     return sequence_;
   }
@@ -148,11 +150,16 @@ public:
     return this->joints_;
   }
 
+  const industrial::joint_data::JointData& getJoints() const
+  {
+    return this->joints_;
+  }
+
   // Overrides - SimpleSerialize
-  bool load(industrial::byte_array::ByteArray *buffer);
+  bool load(industrial::byte_array::ByteArray *buffer) const;
   bool unload(industrial::byte_array::ByteArray *buffer);
 
-  unsigned int byteLength()
+  unsigned int byteLength() const
   {
     return sizeof(industrial::shared_types::shared_int) + this->joints_.byteLength();
   }

--- a/simple_message/include/simple_message/messages/joint_traj_pt_full_message.h
+++ b/simple_message/include/simple_message/messages/joint_traj_pt_full_message.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2013, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef JOINT_TRAJ_PT_FULL_MESSAGE_H
 #define JOINT_TRAJ_PT_FULL_MESSAGE_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/typed_message.h"
@@ -85,7 +87,7 @@ public:
    *
    * \return true if message successfully initialized, otherwise false
    */
-  bool init(industrial::simple_message::SimpleMessage & msg);
+  bool init(const industrial::simple_message::SimpleMessage& msg);
 
   /**
    * \brief Initializes message from a joint trajectory point structure
@@ -93,7 +95,7 @@ public:
    * \param joint trajectory point data structure
    *
    */
-  void init(industrial::joint_traj_pt_full::JointTrajPtFull & point);
+  void init(const industrial::joint_traj_pt_full::JointTrajPtFull& point);
 
   /**
    * \brief Initializes a new message
@@ -102,10 +104,10 @@ public:
   void init();
 
   // Overrides - SimpleSerialize
-  bool load(industrial::byte_array::ByteArray *buffer);
+  bool load(industrial::byte_array::ByteArray *buffer) const;
   bool unload(industrial::byte_array::ByteArray *buffer);
 
-  unsigned int byteLength()
+  unsigned int byteLength() const
   {
     return this->point_.byteLength();
   }
@@ -118,9 +120,6 @@ public:
   void setSequence(industrial::shared_types::shared_int sequence) { point_.setSequence(sequence); }
 
   industrial::joint_traj_pt_full::JointTrajPtFull point_;
-
-private:
-
 
 };
 

--- a/simple_message/include/simple_message/messages/joint_traj_pt_message.h
+++ b/simple_message/include/simple_message/messages/joint_traj_pt_message.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef JOINT_TRAJ_PT_MESSAGE_H
 #define JOINT_TRAJ_PT_MESSAGE_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/typed_message.h"
@@ -85,7 +87,7 @@ public:
    *
    * \return true if message successfully initialized, otherwise false
    */
-  bool init(industrial::simple_message::SimpleMessage & msg);
+  bool init(const industrial::simple_message::SimpleMessage& msg);
 
   /**
    * \brief Initializes message from a joint trajectory point structure
@@ -93,7 +95,7 @@ public:
    * \param joint trajectory point data structure
    *
    */
-  void init(industrial::joint_traj_pt::JointTrajPt & point);
+  void init(const industrial::joint_traj_pt::JointTrajPt& point);
 
   /**
    * \brief Initializes a new message
@@ -102,10 +104,10 @@ public:
   void init();
 
   // Overrides - SimpleSerialize
-  bool load(industrial::byte_array::ByteArray *buffer);
+  bool load(industrial::byte_array::ByteArray *buffer) const;
   bool unload(industrial::byte_array::ByteArray *buffer);
 
-  unsigned int byteLength()
+  unsigned int byteLength() const
   {
     return this->point_.byteLength();
   }
@@ -118,9 +120,6 @@ public:
   void setSequence(industrial::shared_types::shared_int sequence) { point_.setSequence(sequence); }
 
   industrial::joint_traj_pt::JointTrajPt point_;
-
-private:
-
 
 };
 

--- a/simple_message/include/simple_message/messages/robot_status_message.h
+++ b/simple_message/include/simple_message/messages/robot_status_message.h
@@ -32,6 +32,8 @@
 #ifndef ROBOT_STATUS_MESSAGE_H
 #define ROBOT_STATUS_MESSAGE_H
 
+#include "config.h"
+
 #ifndef FLATHEADERS
 #include "simple_message/typed_message.h"
 #include "simple_message/simple_message.h"
@@ -85,7 +87,7 @@ public:
    *
    * \return true if message successfully initialized, otherwise false
    */
-  bool init(industrial::simple_message::SimpleMessage & msg);
+  bool init(const industrial::simple_message::SimpleMessage& msg);
 
   /**
    * \brief Initializes message from a robot status structure
@@ -93,7 +95,7 @@ public:
    * \param status strcutre to initialize from
    *
    */
-  void init(industrial::robot_status::RobotStatus & status);
+  void init(const industrial::robot_status::RobotStatus& status);
 
   /**
    * \brief Initializes a new robot status message
@@ -101,16 +103,14 @@ public:
    */
   void init();
 
-
   // Overrides - SimpleSerialize
-  bool load(industrial::byte_array::ByteArray *buffer);
+  bool load(industrial::byte_array::ByteArray *buffer) const;
   bool unload(industrial::byte_array::ByteArray *buffer);
 
-  unsigned int byteLength()
+  unsigned int byteLength() const
   {
     return this->status_.byteLength();
   }
-  
 
   industrial::robot_status::RobotStatus status_;
 

--- a/simple_message/include/simple_message/ping_handler.h
+++ b/simple_message/include/simple_message/ping_handler.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -32,6 +32,8 @@
 
 #ifndef PING_HANDLER_H
 #define PING_HANDLER_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/message_handler.h"
@@ -79,12 +81,10 @@ bool init(industrial::smpl_msg_connection::SmplMsgConnection* connection);
 * \return true on success, false otherwise (an invalid message type)
 */
 bool init(int msg_type, industrial::smpl_msg_connection::SmplMsgConnection* connection)
-{ return MessageHandler::init(msg_type, connection);};
+{ return MessageHandler::init(msg_type, connection); }
 
 
 private:
-
-
 
  /**
   * \brief Callback executed upon receiving a ping message
@@ -93,7 +93,7 @@ private:
   *
   * \return true on success, false otherwise
   */
- bool internalCB(industrial::simple_message::SimpleMessage & in);
+ bool internalCB(const industrial::simple_message::SimpleMessage& in);
 };
 
 }//ping_handler

--- a/simple_message/include/simple_message/ping_message.h
+++ b/simple_message/include/simple_message/ping_message.h
@@ -32,6 +32,8 @@
 #ifndef PING_MESSAGE_H
 #define PING_MESSAGE_H
 
+#include "config.h"
+
 #ifndef FLATHEADERS
 #include "simple_message/typed_message.h"
 #include "simple_message/simple_message.h"
@@ -80,7 +82,7 @@ public:
    *
    * \return true if message successfully initialized, otherwise false
    */
-  bool init(industrial::simple_message::SimpleMessage & msg);
+  bool init(const industrial::simple_message::SimpleMessage& msg);
 
   /**
    * \brief Initializes a new ping message
@@ -94,14 +96,14 @@ public:
      *
      */
   bool toTopic(industrial::simple_message::SimpleMessage & msg)
-    {
-  	  return false;
-    }
+  {
+    return false;
+  }
 
   // Overrides - SimpleSerialize
-    bool load(industrial::byte_array::ByteArray *buffer){return true;}
-    bool unload(industrial::byte_array::ByteArray *buffer){return true;}
-    unsigned int byteLength(){return 0;}
+  bool load(industrial::byte_array::ByteArray *buffer) const { return true; }
+  bool unload(industrial::byte_array::ByteArray *buffer) { return true; }
+  unsigned int byteLength() const { return 0; }
 
 private:
 

--- a/simple_message/include/simple_message/robot_status.h
+++ b/simple_message/include/simple_message/robot_status.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef ROBOT_STATUS_H
 #define ROBOT_STATUS_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/simple_message.h"
@@ -142,12 +144,12 @@ void init();
 void init(TriState drivesPowered, TriState eStopped, industrial::shared_types::shared_int errorCode, TriState inError,
           TriState inMotion, RobotMode mode, TriState motionPossible);
 
-TriState getDrivesPowered()
+TriState getDrivesPowered() const
 {
   return TriState(drives_powered_);
 }
 
-TriState getEStopped()
+TriState getEStopped() const
 {
   return TriState(e_stopped_);
 }
@@ -157,22 +159,22 @@ industrial::shared_types::shared_int getErrorCode() const
   return error_code_;
 }
 
-TriState getInError()
+TriState getInError() const
 {
   return TriState(in_error_);
 }
 
-TriState getInMotion()
+TriState getInMotion() const
 {
   return TriState(in_motion_);
 }
 
-RobotMode getMode()
+RobotMode getMode() const
 {
   return RobotMode(mode_);
 }
 
-TriState getMotionPossible()
+TriState getMotionPossible() const
 {
   return TriState(motion_possible_);
 }
@@ -217,19 +219,19 @@ void setMotionPossible(TriState motionPossible)
  *
  * \param src (value to copy)
  */
-void copyFrom(RobotStatus &src);
+void copyFrom(const RobotStatus& src);
 
 /**
  * \brief == operator implementation
  *
  * \return true if equal
  */
-bool operator==(RobotStatus &rhs);
+bool operator==(const RobotStatus& rhs) const;
 
 // Overrides - SimpleSerialize
-bool load(industrial::byte_array::ByteArray *buffer);
+bool load(industrial::byte_array::ByteArray *buffer) const;
 bool unload(industrial::byte_array::ByteArray *buffer);
-unsigned int byteLength()
+unsigned int byteLength() const
 {
   return 7 * sizeof(industrial::shared_types::shared_int);
 }

--- a/simple_message/include/simple_message/shared_types.h
+++ b/simple_message/include/simple_message/shared_types.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Software License Agreement (BSD License)
 *
 * Copyright (c) 2011, Southwest Research Institute

--- a/simple_message/include/simple_message/simple_comms_fault_handler.h
+++ b/simple_message/include/simple_message/simple_comms_fault_handler.h
@@ -32,6 +32,8 @@
 #ifndef DEFAULT_COMMS_FAULT_HANDLER_H
 #define DEFAULT_COMMS_FAULT_HANDLER_H
 
+#include "config.h"
+
 #ifndef FLATHEADERS
 #include "simple_message/comms_fault_handler.h"
 #include "simple_message/smpl_msg_connection.h"
@@ -79,25 +81,24 @@ public:
     */
    bool init(industrial::smpl_msg_connection::SmplMsgConnection* connection);
 
+   /**
+    * \brief Send failure callback method: Nothing is performed
+    *
+    */
+   void sendFailCB() { LOG_WARN("Send failure, no callback support"); }
 
    /**
-      * \brief Send failure callback method: Nothing is performed
-      *
-      */
-     void sendFailCB() {LOG_WARN("Send failure, no callback support");};
+    * \brief Receive failure callback method: Nothing is performed
+    *
+    */
+   void receiveFailCB() { LOG_WARN("Receive failure, no callback support"); }
 
-     /**
-      * \brief Receive failure callback method: Nothing is performed
-      *
-      */
-     void receiveFailCB() {LOG_WARN("Receive failure, no callback support");};
-
-     /**
-      * \brief Connection failure callback method: On a connection failure
-      * a blocking reconnection is attempted.
-      *
-      */
-     void connectionFailCB();
+   /**
+    * \brief Connection failure callback method: On a connection failure
+    * a blocking reconnection is attempted.
+    *
+    */
+   void connectionFailCB();
 
 private:
 
@@ -116,7 +117,6 @@ industrial::smpl_msg_connection::SmplMsgConnection* connection_;
   {
     this->connection_ = connection;
   }
-  ;
 
   /**
    * \brief Gets connection for manager

--- a/simple_message/include/simple_message/simple_message.h
+++ b/simple_message/include/simple_message/simple_message.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef SIMPLE_MSG_H
 #define SIMPLE_MSG_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/simple_serialize.h"
@@ -164,7 +166,6 @@ typedef ReplyTypes::ReplyType ReplyType;
 class SimpleMessage
 {
 
-  
 public:
   /**
    * \brief Constructs an empty message
@@ -185,9 +186,9 @@ public:
    *
    * \return true if valid message created
    */
-	bool init(int msgType, int commType, int replyCode,
-	          industrial::byte_array::ByteArray &data );
-            
+  bool init(int msgType, int commType, int replyCode,
+      const industrial::byte_array::ByteArray& data);
+
   /**
    * \brief Initializes a simple message with an emtpy data payload
    *
@@ -198,7 +199,7 @@ public:
    * \return true if valid message created
    */
   bool init(int msgType, int commType, int replyCode);
-  
+
   /**
    * \brief Initializes a simple message from a generic byte array.  The byte
    * array is assumed to hold a valid message with a HEADER and data payload
@@ -207,7 +208,7 @@ public:
    *
    * \return true if valid message created
    */
-  bool init(industrial::byte_array::ByteArray & msg);
+  bool init(industrial::byte_array::ByteArray& msg);
 
    /**
    * \brief Populates a raw byte array with the message.  Any data stored in
@@ -215,7 +216,7 @@ public:
    * 
    * \param byte array to be populated
    */
-  void toByteArray(industrial::byte_array::ByteArray & msg);
+  void toByteArray(industrial::byte_array::ByteArray& msg);
 
   /**
    * \brief Gets size of message header in bytes(fixed)
@@ -223,8 +224,8 @@ public:
    * \return message header size
    */
   static unsigned int getHeaderSize() { return SimpleMessage::HEADER_SIZE; };
-  
-   /**
+
+  /**
    * \brief Gets size of message length member in bytes (fixed)
    *
    * \return message header size
@@ -236,52 +237,51 @@ public:
    *
    * \return message type
    */
-	int getMessageType() {return this->message_type_;};
-  
+  int getMessageType() const { return this->message_type_; }
+
   /**
    * \brief Gets message type(see CommType)
    *
    * \return communications type
    */
-	int getCommType() {return this->comm_type_;};
-  
-    /**
+  int getCommType() const { return this->comm_type_; }
+
+  /**
    * \brief Gets reply code(see ReplyType)
    *
    * \return reply code
    */
-  int getReplyCode() {return this->reply_code_;};
-  
-   /**
+  int getReplyCode() const { return this->reply_code_; }
+
+  /**
    * \brief Gets message length (total size, HEADER + data)
    *
    * \return message length
    */
-	int getMsgLength() {return this->getHeaderSize() + this->data_.getBufferSize();};
-  
-   /**
+  int getMsgLength() const { return this->getHeaderSize() + this->data_.getBufferSize(); }
+
+  /**
    * \brief Gets length of message data portion.
    *
    * \return message data length
    */
-	int getDataLength() {return this->data_.getBufferSize();};
-  
-   /**
+  int getDataLength() const { return this->data_.getBufferSize(); }
+
+  /**
    * \brief Returns a reference to the internal data member
    *
    * \return reference to message data portion.
    */
-  industrial::byte_array::ByteArray & getData() {return this->data_;};
-	
+  industrial::byte_array::ByteArray& getData() { return this->data_; }
+  const industrial::byte_array::ByteArray& getData() const { return this->data_; }
+
   /**
    * \brief performs logical checks to ensure that the message is fully
    * defined and adheres to the message conventions.
    *
    * \return true if message valid, false otherwise
    */
-  bool validateMessage();
-	
-
+  bool validateMessage() const;
 
 private:
 
@@ -289,33 +289,33 @@ private:
    * \brief Message type(see StandardMsgType)
    */
   industrial::shared_types::shared_int message_type_;
-  
-   /**
+
+  /**
    * \brief Communications type(see CommType)
    */
   industrial::shared_types::shared_int comm_type_;
-  
+
   /**
    * \brief Reply code(see ReplyType)
    */
   industrial::shared_types::shared_int reply_code_;
-  
+
   /**
    * \brief Message data portion
    */
-	industrial::byte_array::ByteArray data_;
+  industrial::byte_array::ByteArray data_;
 
   /**
    * \brief Size(in bytes) of message header (fixed)
    */
-	static const unsigned int HEADER_SIZE = sizeof(industrial::shared_types::shared_int) +
-	    sizeof(industrial::shared_types::shared_int) +
-	    sizeof(industrial::shared_types::shared_int);
-      
+  static const unsigned int HEADER_SIZE = sizeof(industrial::shared_types::shared_int) +
+    sizeof(industrial::shared_types::shared_int) +
+    sizeof(industrial::shared_types::shared_int);
+
   /**
    * \brief Size (in bytes) of message length parameter (fixed)
    */
-	static const unsigned int LENGTH_SIZE = sizeof(industrial::shared_types::shared_int);
+  static const unsigned int LENGTH_SIZE = sizeof(industrial::shared_types::shared_int);
 
   /**
    * \brief Sets message type
@@ -323,27 +323,27 @@ private:
    * \param message type
    */
   void setMessageType(int msgType) {this->message_type_ = msgType;};
-  
+
   /**
    * \brief Sets communications type
    *
    * \param communications type
    */
   void setCommType(int commType) {this->comm_type_ = commType;};
-  
+
   /**
    * \brief Sets reply code
    *
    * \param reply code
    */
   void setReplyCode(int replyCode) {this->reply_code_ = replyCode;};
-  
+
   /**
    * \brief Sets data portion
    *
    * \param data portion
    */
-  void setData(industrial::byte_array::ByteArray & data);
+  void setData(const industrial::byte_array::ByteArray& data);
 };
 
 }//namespace simple_message

--- a/simple_message/include/simple_message/simple_serialize.h
+++ b/simple_message/include/simple_message/simple_serialize.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -32,6 +32,8 @@
 #ifndef SIMPLE_SERIALIZE_H
 #define SIMPLE_SERIALIZE_H
 
+#include "config.h"
+
 #ifndef FLATHEADERS
 #include "simple_message/byte_array.h"
 #else
@@ -62,7 +64,7 @@ public:
    *
    * \return true on success, false otherwise (buffer not large enough)
    */
-  virtual bool load(industrial::byte_array::ByteArray *buffer)=0;
+  virtual bool load(industrial::byte_array::ByteArray *buffer) const = 0;
 
   /**
    * \brief Virtual method for unloading an object from a ByteArray
@@ -74,7 +76,7 @@ public:
    *
    * \return true on success, false otherwise (buffer not large enough)
    */
-  virtual bool unload(industrial::byte_array::ByteArray *buffer)=0;
+  virtual bool unload(industrial::byte_array::ByteArray *buffer) = 0;
 
   /**
    * \brief Virtual method returns the object size when packed into a
@@ -82,7 +84,7 @@ public:
    *
    * \return object size (in bytes)
    */
-  virtual unsigned int byteLength()=0;
+  virtual unsigned int byteLength() const = 0;
 
 };
 

--- a/simple_message/include/simple_message/smpl_msg_connection.h
+++ b/simple_message/include/simple_message/smpl_msg_connection.h
@@ -32,6 +32,8 @@
 #ifndef SIMPLE_MESSAGE_CONNECTION_H
 #define SIMPLE_MESSAGE_CONNECTION_H
 
+#include "config.h"
+
 #ifndef FLATHEADERS
 #include "simple_message/byte_array.h"
 #include "simple_message/simple_message.h"
@@ -64,7 +66,7 @@ class SmplMsgConnection
 public:
 
   // Message
-  
+
   /**
    * \brief Sends a message using the data connection
    *
@@ -73,7 +75,7 @@ public:
    * \return true if successful
    */
   virtual bool sendMsg(industrial::simple_message::SimpleMessage & message);
-  
+
   /**
    * \brief Receives a message using the data connection
    *
@@ -82,7 +84,7 @@ public:
    * \return true if successful
    */
   virtual bool receiveMsg(industrial::simple_message::SimpleMessage & message);
-  
+
   /**
    * \brief Performs a complete send and receive.  This is helpful when sending
    * a message that requires and explicit reply
@@ -94,7 +96,7 @@ public:
    * \return true if successful
    */
   bool sendAndReceiveMsg(industrial::simple_message::SimpleMessage & send,
-                         industrial::simple_message::SimpleMessage & recv, 
+                         industrial::simple_message::SimpleMessage & recv,
                          bool verbose = false);
 
   /**
@@ -102,7 +104,7 @@ public:
    *
    * \return true if connected
    */
-  virtual bool isConnected()=0;
+  virtual bool isConnected() const=0;
 
   /**
    * \brief connects to the remote host
@@ -123,7 +125,7 @@ private:
    * \return true if successful
    */
   virtual bool sendBytes(industrial::byte_array::ByteArray & buffer) =0;
-  
+
   /**
    * \brief Method used by receive message interface method.  This should be overridden 
    * for the specific connection type

--- a/simple_message/include/simple_message/socket/simple_socket.h
+++ b/simple_message/include/simple_message/socket/simple_socket.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef SIMPLE_SOCKET_H
 #define SIMPLE_SOCKET_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/log_wrapper.h"
@@ -156,11 +158,11 @@ public:
      */
   virtual ~SimpleSocket(){}
 
-  bool isConnected()
+  bool isConnected() const
   {
     return connected_;
   }
-  
+
   // Internally set the state of the connection to be disconnected.
   // This is needed in UDP connections to signal when a timeout has occurred 
   // and the connection needs to be reestablished using the handshake protocol.
@@ -168,7 +170,7 @@ public:
   {
     setConnected(false);
   }
-  
+
   /**
    * \brief returns true if socket data is ready to receive
    *
@@ -194,7 +196,7 @@ protected:
    * \brief address/port of remote socket
    */
   sockaddr_in sockaddr_;
-  
+
   /**
    * \brief flag indicating socket connection status
    */
@@ -221,7 +223,7 @@ protected:
    */
   char buffer_[MAX_BUFFER_SIZE + 1];
 
-  int  getSockHandle() const
+  int getSockHandle() const
   {
     return sock_handle_;
   }
@@ -255,7 +257,7 @@ protected:
   {
     LOG_ERROR("%s, rc: %d. Error: '%s' (errno: %d)", msg, rc, strerror(error_no), error_no);
   }
-  
+
   // Send/Receive functions (inherited classes should override raw methods
   // Virtual
   bool sendBytes(industrial::byte_array::ByteArray & buffer);

--- a/simple_message/include/simple_message/socket/tcp_client.h
+++ b/simple_message/include/simple_message/socket/tcp_client.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef TCP_CLIENT_H
 #define TCP_CLIENT_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/socket/tcp_socket.h"

--- a/simple_message/include/simple_message/socket/tcp_server.h
+++ b/simple_message/include/simple_message/socket/tcp_server.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef TCP_SERVER_H
 #define TCP_SERVER_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/socket/tcp_socket.h"

--- a/simple_message/include/simple_message/socket/tcp_socket.h
+++ b/simple_message/include/simple_message/socket/tcp_socket.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -31,6 +31,8 @@
 
 #ifndef TCP_SOCKET_H
 #define TCP_SOCKET_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/socket/simple_socket.h"

--- a/simple_message/include/simple_message/socket/udp_client.h
+++ b/simple_message/include/simple_message/socket/udp_client.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Yaskawa America, Inc.
@@ -31,6 +31,8 @@
 
 #ifndef UDP_CLIENT_H
 #define UDP_CLIENT_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/socket/udp_socket.h"

--- a/simple_message/include/simple_message/socket/udp_server.h
+++ b/simple_message/include/simple_message/socket/udp_server.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Yaskawa America, Inc.
@@ -31,6 +31,8 @@
 
 #ifndef UDP_SERVER_H
 #define UDP_SERVER_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/socket/udp_socket.h"

--- a/simple_message/include/simple_message/socket/udp_socket.h
+++ b/simple_message/include/simple_message/socket/udp_socket.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Yaskawa America, Inc.
@@ -31,6 +31,8 @@
 
 #ifndef UDP_SOCKET_H
 #define UDP_SOCKET_H
+
+#include "config.h"
 
 #ifndef FLATHEADERS
 #include "simple_message/socket/simple_socket.h"
@@ -90,4 +92,3 @@ protected:
 } //industrial
 
 #endif
-

--- a/simple_message/include/simple_message/typed_message.h
+++ b/simple_message/include/simple_message/typed_message.h
@@ -32,6 +32,8 @@
 #ifndef TYPED_MESSAGE_H
 #define TYPED_MESSAGE_H
 
+#include "config.h"
+
 #ifndef FLATHEADERS
 #include "simple_message/simple_message.h"
 #include "simple_message/byte_array.h"
@@ -80,7 +82,7 @@ public:
    *
    * \return true if message successfully initialized, otherwise false
    */
-  virtual bool init(industrial::simple_message::SimpleMessage & msg)=0;
+  virtual bool init(const industrial::simple_message::SimpleMessage& msg)=0;
 
   /**
    * \brief Initializes a new empty message
@@ -93,13 +95,13 @@ public:
    *
    * \return true if message successfully initialized, otherwise false
    */
-  virtual bool toRequest(industrial::simple_message::SimpleMessage & msg)
+  virtual bool toRequest(industrial::simple_message::SimpleMessage& msg) const
   {
-	  industrial::byte_array::ByteArray data;
-	  data.load(*this);
-	  return msg.init(this->getMessageType(),
-			  industrial::simple_message::CommTypes::SERVICE_REQUEST,
-			  industrial::simple_message::ReplyTypes::INVALID, data);
+    industrial::byte_array::ByteArray data;
+    data.load(*this);
+    return msg.init(this->getMessageType(),
+        industrial::simple_message::CommTypes::SERVICE_REQUEST,
+        industrial::simple_message::ReplyTypes::INVALID, data);
   }
 
   /**
@@ -107,28 +109,29 @@ public:
    *
    * \return true if message successfully initialized, otherwise false
    */
-  virtual bool toReply(industrial::simple_message::SimpleMessage & msg,
-		  industrial::simple_message::ReplyType reply)
+  virtual bool toReply(industrial::simple_message::SimpleMessage& msg,
+      industrial::simple_message::ReplyType reply) const
   {
-	  industrial::byte_array::ByteArray data;
-	data.load(*this);
-	return msg.init(this->getMessageType(),
-			industrial::simple_message::CommTypes::SERVICE_REPLY,
-			reply, data);
+    industrial::byte_array::ByteArray data;
+    data.load(*this);
+    return msg.init(this->getMessageType(),
+        industrial::simple_message::CommTypes::SERVICE_REPLY,
+        reply, data);
   }
   /**
    * \brief creates a simple_message topic
    *
    * \return true if message successfully initialized, otherwise false
    */
-  virtual bool toTopic(industrial::simple_message::SimpleMessage & msg)
+  virtual bool toTopic(industrial::simple_message::SimpleMessage& msg) const
   {
-	  industrial::byte_array::ByteArray data;
+    industrial::byte_array::ByteArray data;
     data.load(*this);
     return msg.init(this->getMessageType(),
-    		industrial::simple_message::CommTypes::TOPIC,
-    		industrial::simple_message::ReplyTypes::INVALID, data);
+        industrial::simple_message::CommTypes::TOPIC,
+        industrial::simple_message::ReplyTypes::INVALID, data);
   }
+
   /**
    * \brief gets message type (enumeration)
    *
@@ -138,7 +141,7 @@ public:
   {
     return message_type_;
   }
-  
+
   /**
    * \brief Gets the communication type of the message
    * 
@@ -160,7 +163,7 @@ protected:
   {
     this->message_type_ = message_type;
   }
-  
+
   /**
    * \brief Sets the communication type of the message
    *
@@ -178,7 +181,7 @@ private:
    */
 
   int message_type_;
-    
+
   /**
    * \brief Communications type (see simple_message::CommTypes::CommType)
    */

--- a/simple_message/src/byte_array.cpp
+++ b/simple_message/src/byte_array.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2015, Southwest Research Institute
@@ -83,7 +83,7 @@ bool ByteArray::init(const char* buffer, const shared_int byte_size)
   return rtn;
 }
 
-void ByteArray::copyFrom(ByteArray & buffer)
+void ByteArray::copyFrom(const ByteArray& buffer)
 {
   if (buffer.getBufferSize() != 0)
   {
@@ -95,7 +95,7 @@ void ByteArray::copyFrom(ByteArray & buffer)
   }
 }
 
-void ByteArray::copyTo(std::vector<char> &out)
+void ByteArray::copyTo(std::vector<char>& out)
 {
   out.assign(buffer_.begin(), buffer_.end());
 }
@@ -166,17 +166,17 @@ bool ByteArray::load(shared_int value)
   return this->load(&value, sizeof(shared_int));
 }
 
-bool ByteArray::load(simple_serialize::SimpleSerialize &value)
+bool ByteArray::load(const simple_serialize::SimpleSerialize& value)
 {
   LOG_COMM("Executing byte array load through simple serialize");
   return value.load(this);
 }
 
-bool ByteArray::load(ByteArray &value)
+bool ByteArray::load(const ByteArray& value)
 {
   LOG_COMM("Executing byte array load through byte array");
-  std::deque<char>& src = value.buffer_;
-  std::deque<char>& dest  = this->buffer_;
+  const std::deque<char>& src = value.buffer_;
+  std::deque<char>& dest = this->buffer_;
 
   if (this->getBufferSize()+value.getBufferSize() > this->getMaxBufferSize())
   {
@@ -190,7 +190,6 @@ bool ByteArray::load(ByteArray &value)
 
 bool ByteArray::load(void* value, const shared_int byte_size)
 {
-
   bool rtn;
 
   LOG_COMM("Executing byte array load through void*, size: %d", byte_size);
@@ -234,7 +233,6 @@ bool ByteArray::unload(shared_bool & value)
 {
   shared_bool rtn = this->unload(&value, sizeof(shared_bool));
   return rtn;
-
 }
 
 bool ByteArray::unload(shared_real &value)
@@ -384,12 +382,12 @@ bool ByteArray::unloadFront(void* value, const industrial::shared_types::shared_
   return rtn;
 }
 
-unsigned int ByteArray::getBufferSize()
+unsigned int ByteArray::getBufferSize() const
 {
   return this->buffer_.size();
 }
 
-unsigned int ByteArray::getMaxBufferSize()
+unsigned int ByteArray::getMaxBufferSize() const
 {
   return this->buffer_.max_size();
 }

--- a/simple_message/src/joint_data.cpp
+++ b/simple_message/src/joint_data.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -102,9 +102,8 @@ shared_real JointData::getJoint(shared_int index) const
   this->getJoint(index, rtn);
   return rtn;
 }
-  
 
-void JointData::copyFrom(JointData &src)
+void JointData::copyFrom(const JointData& src)
 {
   shared_real value = 0.0;
 
@@ -115,7 +114,7 @@ void JointData::copyFrom(JointData &src)
   }
 }
 
-bool JointData::operator==(JointData &rhs)
+bool JointData::operator==(const JointData& rhs) const
 {
   bool rtn = true;
 
@@ -135,7 +134,7 @@ bool JointData::operator==(JointData &rhs)
 
 }
 
-bool JointData::load(industrial::byte_array::ByteArray *buffer)
+bool JointData::load(industrial::byte_array::ByteArray *buffer) const
 {
   bool rtn = false;
   shared_real value = 0.0;
@@ -175,4 +174,3 @@ bool JointData::unload(industrial::byte_array::ByteArray *buffer)
 
 }
 }
-

--- a/simple_message/src/joint_feedback.cpp
+++ b/simple_message/src/joint_feedback.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2013, Southwest Research Institute
@@ -68,9 +68,9 @@ void JointFeedback::init()
 void JointFeedback::init(industrial::shared_types::shared_int robot_id,
           industrial::shared_types::shared_int valid_fields,
           industrial::shared_types::shared_real time,
-          industrial::joint_data::JointData & positions,
-          industrial::joint_data::JointData & velocities,
-          industrial::joint_data::JointData & accelerations)
+          const industrial::joint_data::JointData& positions,
+          const industrial::joint_data::JointData& velocities,
+          const industrial::joint_data::JointData& accelerations)
 {
   this->setRobotID(robot_id);
   this->setTime(time);
@@ -80,7 +80,7 @@ void JointFeedback::init(industrial::shared_types::shared_int robot_id,
   this->valid_fields_ = valid_fields;  // must happen after others are set
 }
 
-void JointFeedback::copyFrom(JointFeedback &src)
+void JointFeedback::copyFrom(const JointFeedback& src)
 {
   this->setRobotID(src.getRobotID());
   src.getTime(this->time_);
@@ -90,7 +90,7 @@ void JointFeedback::copyFrom(JointFeedback &src)
   this->valid_fields_ = src.valid_fields_;
 }
 
-bool JointFeedback::operator==(JointFeedback &rhs)
+bool JointFeedback::operator==(const JointFeedback& rhs) const
 {
   return this->robot_id_ == rhs.robot_id_ &&
          this->valid_fields_ == rhs.valid_fields_ &&
@@ -100,7 +100,7 @@ bool JointFeedback::operator==(JointFeedback &rhs)
          ( !is_valid(ValidFieldTypes::ACCELERATION) || (this->accelerations_ == rhs.accelerations_) );
 }
 
-bool JointFeedback::load(industrial::byte_array::ByteArray *buffer)
+bool JointFeedback::load(industrial::byte_array::ByteArray *buffer) const
 {
   LOG_COMM("Executing joint feedback load");
 
@@ -190,4 +190,3 @@ bool JointFeedback::unload(industrial::byte_array::ByteArray *buffer)
 
 }
 }
-

--- a/simple_message/src/joint_traj.cpp
+++ b/simple_message/src/joint_traj.cpp
@@ -50,6 +50,7 @@ JointTraj::JointTraj(void)
 {
 	this->init();
 }
+
 JointTraj::~JointTraj(void)
 {
 
@@ -66,7 +67,7 @@ void JointTraj::init()
 	}
 }
 
-bool JointTraj::addPoint(JointTrajPt & point)
+bool JointTraj::addPoint(const JointTrajPt& point)
 {
 	bool rtn = false;
 
@@ -85,7 +86,7 @@ bool JointTraj::addPoint(JointTrajPt & point)
 	return rtn;
 }
 
-bool JointTraj::getPoint(shared_int index, JointTrajPt & point)
+bool JointTraj::getPoint(shared_int index, JointTrajPt& point) const
 {
 	bool rtn = false;
 
@@ -102,7 +103,7 @@ bool JointTraj::getPoint(shared_int index, JointTrajPt & point)
 	return rtn;
 }
 
-void JointTraj::copyFrom(JointTraj &src)
+void JointTraj::copyFrom(const JointTraj& src)
 {
 	JointTrajPt value;
 
@@ -114,7 +115,7 @@ void JointTraj::copyFrom(JointTraj &src)
 	}
 }
 
-bool JointTraj::operator==(JointTraj &rhs)
+bool JointTraj::operator==(const JointTraj& rhs) const
 {
 	bool rtn = true;
 
@@ -145,8 +146,7 @@ bool JointTraj::operator==(JointTraj &rhs)
 	return rtn;
 }
 
-
-bool JointTraj::load(industrial::byte_array::ByteArray *buffer)
+bool JointTraj::load(industrial::byte_array::ByteArray *buffer) const
 {
 	bool rtn = false;
 	JointTrajPt value;
@@ -203,4 +203,3 @@ bool JointTraj::unload(industrial::byte_array::ByteArray *buffer)
 
 }
 }
-

--- a/simple_message/src/joint_traj_pt.cpp
+++ b/simple_message/src/joint_traj_pt.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -63,7 +63,7 @@ void JointTrajPt::init()
   this->duration_ = 0.0;
 }
 
-void JointTrajPt::init(shared_int sequence, JointData & position, shared_real velocity, shared_real duration)
+void JointTrajPt::init(shared_int sequence, const JointData& position, shared_real velocity, shared_real duration)
 {
   this->setJointPosition(position);
   this->setSequence(sequence);
@@ -71,7 +71,7 @@ void JointTrajPt::init(shared_int sequence, JointData & position, shared_real ve
   this->setDuration(duration);
 }
 
-void JointTrajPt::copyFrom(JointTrajPt &src)
+void JointTrajPt::copyFrom(const JointTrajPt& src)
 {
   this->setSequence(src.getSequence());
   src.getJointPosition(this->joint_position_);
@@ -79,14 +79,13 @@ void JointTrajPt::copyFrom(JointTrajPt &src)
   this->setDuration(src.getDuration());
 }
 
-bool JointTrajPt::operator==(JointTrajPt &rhs)
+bool JointTrajPt::operator==(const JointTrajPt& rhs) const
 {
   return this->joint_position_ == rhs.joint_position_ && this->sequence_ == rhs.sequence_
       && this->velocity_ == rhs.velocity_ && this->duration_ == rhs.duration_;
-
 }
 
-bool JointTrajPt::load(industrial::byte_array::ByteArray *buffer)
+bool JointTrajPt::load(industrial::byte_array::ByteArray *buffer) const
 {
   bool rtn = false;
 

--- a/simple_message/src/joint_traj_pt_full.cpp
+++ b/simple_message/src/joint_traj_pt_full.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2013, Southwest Research Institute
@@ -50,9 +50,9 @@ JointTrajPtFull::JointTrajPtFull(void)
 {
   this->init();
 }
+
 JointTrajPtFull::~JointTrajPtFull(void)
 {
-
 }
 
 void JointTrajPtFull::init()
@@ -70,9 +70,9 @@ void JointTrajPtFull::init(industrial::shared_types::shared_int robot_id,
           industrial::shared_types::shared_int sequence,
           industrial::shared_types::shared_int valid_fields,
           industrial::shared_types::shared_real time,
-          industrial::joint_data::JointData & positions,
-          industrial::joint_data::JointData & velocities,
-          industrial::joint_data::JointData & accelerations)
+          const industrial::joint_data::JointData& positions,
+          const industrial::joint_data::JointData& velocities,
+          const industrial::joint_data::JointData& accelerations)
 {
   this->setRobotID(robot_id);
   this->setSequence(sequence);
@@ -83,7 +83,7 @@ void JointTrajPtFull::init(industrial::shared_types::shared_int robot_id,
   this->valid_fields_ = valid_fields;  // must happen after others are set
 }
 
-void JointTrajPtFull::copyFrom(JointTrajPtFull &src)
+void JointTrajPtFull::copyFrom(const JointTrajPtFull& src)
 {
   this->setRobotID(src.getRobotID());
   this->setSequence(src.getSequence());
@@ -94,7 +94,7 @@ void JointTrajPtFull::copyFrom(JointTrajPtFull &src)
   this->valid_fields_ = src.valid_fields_;
 }
 
-bool JointTrajPtFull::operator==(JointTrajPtFull &rhs)
+bool JointTrajPtFull::operator==(const JointTrajPtFull& rhs) const
 {
   return this->robot_id_ == rhs.robot_id_ &&
          this->sequence_ == rhs.sequence_ &&
@@ -105,7 +105,7 @@ bool JointTrajPtFull::operator==(JointTrajPtFull &rhs)
          ( !is_valid(ValidFieldTypes::ACCELERATION) || (this->accelerations_ == rhs.accelerations_) );
 }
 
-bool JointTrajPtFull::load(industrial::byte_array::ByteArray *buffer)
+bool JointTrajPtFull::load(industrial::byte_array::ByteArray *buffer) const
 {
   LOG_COMM("Executing joint trajectory point load");
 
@@ -207,4 +207,3 @@ bool JointTrajPtFull::unload(industrial::byte_array::ByteArray *buffer)
 
 }
 }
-

--- a/simple_message/src/message_handler.cpp
+++ b/simple_message/src/message_handler.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -50,16 +50,14 @@ MessageHandler::MessageHandler(void)
   this->setMsgType(StandardMsgTypes::INVALID);
 }
 
-
 MessageHandler::~MessageHandler(void)
 {
 }
 
-
 bool MessageHandler::init(int msg_type, SmplMsgConnection* connection)
 {
   bool rtn = false;
-  
+
   if (StandardMsgTypes::INVALID != msg_type)
   {
     if (NULL != connection)
@@ -73,22 +71,20 @@ bool MessageHandler::init(int msg_type, SmplMsgConnection* connection)
       LOG_ERROR("Message connection is NULL");
       rtn = false;
     }
-    }
+  }
   else
   {
     LOG_ERROR("Message handler type: %d, not valid", msg_type);
     rtn = false;
-    }
-    
+  }
+
   return rtn;
 }
 
-    
-    
-bool MessageHandler::callback(SimpleMessage & in)
+bool MessageHandler::callback(const SimpleMessage& in)
 {
   bool rtn = false;
-  
+
   if (validateMsg(in))
   {
     this->internalCB(in);
@@ -98,15 +94,14 @@ bool MessageHandler::callback(SimpleMessage & in)
     LOG_ERROR("Invalid message passed to callback");
     rtn = true;
   }
-  
+
   return rtn;
 }
 
-
-bool MessageHandler::validateMsg(SimpleMessage & in)
+bool MessageHandler::validateMsg(const SimpleMessage& in) const
 {
   bool rtn = false;
-  
+
   if (in.validateMessage())
   {
     if (in.getMessageType() == this->getMsgType())
@@ -116,7 +111,7 @@ bool MessageHandler::validateMsg(SimpleMessage & in)
     else
     {
       LOG_WARN("Message type: %d, doesn't match handler type: %d",
-                  in.getMessageType(), this->getMsgType());
+          in.getMessageType(), this->getMsgType());
       rtn = false;
     }
   }
@@ -126,7 +121,6 @@ bool MessageHandler::validateMsg(SimpleMessage & in)
   }
 
   return rtn;
-  
 }
 
 } // namespace message_handler

--- a/simple_message/src/message_manager.cpp
+++ b/simple_message/src/message_manager.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -79,7 +79,6 @@ bool MessageManager::init(SmplMsgConnection* connection)
 
   LOG_INFO("Initializing message manager with default comms fault handler");
 
-
   if (NULL != connection)
   {
     this->getDefaultCommsFaultHandler().init(connection);
@@ -99,35 +98,33 @@ bool MessageManager::init(SmplMsgConnection* connection, CommsFaultHandler* faul
 {
   bool rtn = false;
 
-    LOG_INFO("Initializing message manager");
+  LOG_INFO("Initializing message manager");
 
-    if (NULL != connection && NULL != fault_handler)
+  if (NULL != connection && NULL != fault_handler)
+  {
+    this->setConnection(connection);
+    this->getPingHandler().init(connection);
+    this->setCommsFaultHandler(fault_handler);
+
+    if (this->add(&this->getPingHandler()))
     {
-      this->setConnection(connection);
-      this->getPingHandler().init(connection);
-      this->setCommsFaultHandler(fault_handler);
-
-      if (this->add(&this->getPingHandler()))
-      {
-        rtn = true;
-      }
-      else
-      {
-        rtn = false;
-        LOG_WARN("Failed to add ping handler, manager won't respond to pings");
-      }
-
+      rtn = true;
     }
     else
     {
-      LOG_ERROR("NULL connection or NULL fault handler passed into manager init");
       rtn = false;
+      LOG_WARN("Failed to add ping handler, manager won't respond to pings");
     }
 
-    return rtn;
+  }
+  else
+  {
+    LOG_ERROR("NULL connection or NULL fault handler passed into manager init");
+    rtn = false;
   }
 
-
+  return rtn;
+}
 
 void MessageManager::spinOnce()
 {
@@ -198,7 +195,7 @@ void MessageManager::spin()
   }
 }
 
-bool MessageManager::add(MessageHandler * handler, bool allow_replace)
+bool MessageManager::add(MessageHandler* handler, bool allow_replace)
 {
   int idx = -1;
   bool rtn = false;
@@ -263,8 +260,8 @@ int MessageManager::getHandlerIdx(int msg_type)
 
     if (temp->getMsgType() == msg_type)
     {
-        rtn = i;
-        break;
+      rtn = i;
+      break;
     }
   }
 

--- a/simple_message/src/messages/joint_feedback_message.cpp
+++ b/simple_message/src/messages/joint_feedback_message.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2013, Southwest Research Institute
@@ -60,7 +60,7 @@ JointFeedbackMessage::~JointFeedbackMessage(void)
 
 }
 
-bool JointFeedbackMessage::init(industrial::simple_message::SimpleMessage & msg)
+bool JointFeedbackMessage::init(const industrial::simple_message::SimpleMessage& msg)
 {
   bool rtn = false;
   ByteArray data = msg.getData();
@@ -77,7 +77,7 @@ bool JointFeedbackMessage::init(industrial::simple_message::SimpleMessage & msg)
   return rtn;
 }
 
-void JointFeedbackMessage::init(industrial::joint_feedback::JointFeedback & data)
+void JointFeedbackMessage::init(const industrial::joint_feedback::JointFeedback& data)
 {
   this->init();
   this->data_.copyFrom(data);
@@ -89,7 +89,7 @@ void JointFeedbackMessage::init()
   this->data_.init();
 }
 
-bool JointFeedbackMessage::load(ByteArray *buffer)
+bool JointFeedbackMessage::load(ByteArray *buffer) const
 {
   bool rtn = false;
   LOG_COMM("Executing joint feedback message load");
@@ -124,4 +124,3 @@ bool JointFeedbackMessage::unload(ByteArray *buffer)
 
 }
 }
-

--- a/simple_message/src/messages/joint_message.cpp
+++ b/simple_message/src/messages/joint_message.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -62,7 +62,7 @@ JointMessage::~JointMessage(void)
 
 }
 
-bool JointMessage::init(industrial::simple_message::SimpleMessage & msg)
+bool JointMessage::init(const industrial::simple_message::SimpleMessage& msg)
 {
   bool rtn = false;
   ByteArray data = msg.getData();
@@ -93,7 +93,7 @@ void JointMessage::setSequence(shared_int sequence)
   this->sequence_ = sequence;
 }
 
-void JointMessage::init(shared_int seq, JointData& joints)
+void JointMessage::init(shared_int seq, const JointData& joints)
 {
   this->setSequence(seq);
   this->joints_.copyFrom(joints);
@@ -105,7 +105,7 @@ void JointMessage::init()
   this->joints_.init();
 }
 
-bool JointMessage::load(ByteArray *buffer)
+bool JointMessage::load(ByteArray *buffer) const
 {
   bool rtn = false;
   LOG_COMM("Executing joint message load");
@@ -158,4 +158,3 @@ bool JointMessage::unload(ByteArray *buffer)
 
 }
 }
-

--- a/simple_message/src/messages/joint_traj_pt_full_message.cpp
+++ b/simple_message/src/messages/joint_traj_pt_full_message.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2013, Southwest Research Institute
@@ -61,7 +61,7 @@ JointTrajPtFullMessage::~JointTrajPtFullMessage(void)
 
 }
 
-bool JointTrajPtFullMessage::init(industrial::simple_message::SimpleMessage & msg)
+bool JointTrajPtFullMessage::init(const industrial::simple_message::SimpleMessage& msg)
 {
   bool rtn = false;
   ByteArray data = msg.getData();
@@ -78,7 +78,7 @@ bool JointTrajPtFullMessage::init(industrial::simple_message::SimpleMessage & ms
   return rtn;
 }
 
-void JointTrajPtFullMessage::init(industrial::joint_traj_pt_full::JointTrajPtFull & point)
+void JointTrajPtFullMessage::init(const industrial::joint_traj_pt_full::JointTrajPtFull& point)
 {
   this->init();
   this->point_.copyFrom(point);
@@ -90,8 +90,7 @@ void JointTrajPtFullMessage::init()
   this->point_.init();
 }
 
-
-bool JointTrajPtFullMessage::load(ByteArray *buffer)
+bool JointTrajPtFullMessage::load(ByteArray *buffer) const
 {
   bool rtn = false;
   LOG_COMM("Executing joint traj. pt. message load");
@@ -126,4 +125,3 @@ bool JointTrajPtFullMessage::unload(ByteArray *buffer)
 
 }
 }
-

--- a/simple_message/src/messages/joint_traj_pt_message.cpp
+++ b/simple_message/src/messages/joint_traj_pt_message.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -61,7 +61,7 @@ JointTrajPtMessage::~JointTrajPtMessage(void)
 
 }
 
-bool JointTrajPtMessage::init(industrial::simple_message::SimpleMessage & msg)
+bool JointTrajPtMessage::init(const industrial::simple_message::SimpleMessage& msg)
 {
   bool rtn = false;
   ByteArray data = msg.getData();
@@ -78,7 +78,7 @@ bool JointTrajPtMessage::init(industrial::simple_message::SimpleMessage & msg)
   return rtn;
 }
 
-void JointTrajPtMessage::init(industrial::joint_traj_pt::JointTrajPt & point)
+void JointTrajPtMessage::init(const industrial::joint_traj_pt::JointTrajPt& point)
 {
 	this->init();
 	this->point_.copyFrom(point);
@@ -90,8 +90,7 @@ void JointTrajPtMessage::init()
   this->point_.init();
 }
 
-
-bool JointTrajPtMessage::load(ByteArray *buffer)
+bool JointTrajPtMessage::load(ByteArray *buffer) const
 {
 	bool rtn = false;
 	LOG_COMM("Executing joint traj. pt. message load");
@@ -114,7 +113,7 @@ bool JointTrajPtMessage::unload(ByteArray *buffer)
 
   if (buffer->unload(this->point_))
   {
-	  rtn = true;
+    rtn = true;
   }
   else
   {
@@ -126,4 +125,3 @@ bool JointTrajPtMessage::unload(ByteArray *buffer)
 
 }
 }
-

--- a/simple_message/src/messages/robot_status_message.cpp
+++ b/simple_message/src/messages/robot_status_message.cpp
@@ -61,7 +61,7 @@ RobotStatusMessage::~RobotStatusMessage(void)
 
 }
 
-bool RobotStatusMessage::init(industrial::simple_message::SimpleMessage & msg)
+bool RobotStatusMessage::init(const industrial::simple_message::SimpleMessage& msg)
 {
   bool rtn = false;
   ByteArray data = msg.getData();
@@ -79,7 +79,7 @@ bool RobotStatusMessage::init(industrial::simple_message::SimpleMessage & msg)
   return rtn;
 }
 
-void RobotStatusMessage::init(industrial::robot_status::RobotStatus & status)
+void RobotStatusMessage::init(const industrial::robot_status::RobotStatus& status)
 {
   this->init();
   this->status_.copyFrom(status);
@@ -91,7 +91,7 @@ void RobotStatusMessage::init()
   this->status_.init();
 }
 
-bool RobotStatusMessage::load(ByteArray *buffer)
+bool RobotStatusMessage::load(ByteArray *buffer) const
 {
   bool rtn = false;
   LOG_COMM("Executing robot status message load");

--- a/simple_message/src/ping_handler.cpp
+++ b/simple_message/src/ping_handler.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Software License Agreement (BSD License) 
 *
 * Copyright (c) 2011, Southwest Research Institute
@@ -52,7 +52,7 @@ bool PingHandler::init(industrial::smpl_msg_connection::SmplMsgConnection* conne
   return this->init(StandardMsgTypes::PING, connection);
 }
 
-bool PingHandler::internalCB(industrial::simple_message::SimpleMessage & in)
+bool PingHandler::internalCB(const industrial::simple_message::SimpleMessage& in)
 {
   bool rtn = false;
   PingMessage ping;
@@ -93,6 +93,3 @@ bool PingHandler::internalCB(industrial::simple_message::SimpleMessage & in)
 
 }//namespace ping_handler
 }//namespace industrial
-
-
-

--- a/simple_message/src/ping_message.cpp
+++ b/simple_message/src/ping_message.cpp
@@ -57,8 +57,7 @@ PingMessage::~PingMessage(void)
 
 }
 
-
-bool PingMessage::init(SimpleMessage & msg)
+bool PingMessage::init(const SimpleMessage& msg)
 {
   bool rtn = false;
 
@@ -75,7 +74,6 @@ bool PingMessage::init(SimpleMessage & msg)
 
   return rtn;
 }
-
 
 void PingMessage::init()
 {

--- a/simple_message/src/robot_status.cpp
+++ b/simple_message/src/robot_status.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -112,9 +112,9 @@ RobotStatus::RobotStatus(void)
 {
   this->init();
 }
+
 RobotStatus::~RobotStatus(void)
 {
-
 }
 
 void RobotStatus::init()
@@ -135,7 +135,7 @@ void RobotStatus::init(TriState drivesPowered, TriState eStopped, industrial::sh
   this->setMotionPossible(motionPossible);
 }
 
-void RobotStatus::copyFrom(RobotStatus &src)
+void RobotStatus::copyFrom(const RobotStatus& src)
 {
   this->setDrivesPowered(src.getDrivesPowered());
   this->setEStopped(src.getEStopped());
@@ -146,14 +146,14 @@ void RobotStatus::copyFrom(RobotStatus &src)
   this->setMotionPossible(src.getMotionPossible());
 }
 
-bool RobotStatus::operator==(RobotStatus &rhs)
+bool RobotStatus::operator==(const RobotStatus& rhs) const
 {
   return this->drives_powered_ == rhs.drives_powered_ && this->e_stopped_ == rhs.e_stopped_
       && this->error_code_ == rhs.error_code_ && this->in_error_ == rhs.in_error_ && this->in_motion_ == rhs.in_motion_
       && this->mode_ == rhs.mode_ && this->motion_possible_ == rhs.motion_possible_;
 }
 
-bool RobotStatus::load(industrial::byte_array::ByteArray *buffer)
+bool RobotStatus::load(industrial::byte_array::ByteArray *buffer) const
 {
   bool rtn = false;
 
@@ -201,4 +201,3 @@ bool RobotStatus::unload(industrial::byte_array::ByteArray *buffer)
 
 }
 }
-

--- a/simple_message/src/simple_comms_fault_handler.cpp
+++ b/simple_message/src/simple_comms_fault_handler.cpp
@@ -47,7 +47,6 @@ SimpleCommsFaultHandler::SimpleCommsFaultHandler()
   this->connection_ = NULL;
 }
 
-
 SimpleCommsFaultHandler::~SimpleCommsFaultHandler()
 {
 }
@@ -72,7 +71,6 @@ bool SimpleCommsFaultHandler::init(industrial::smpl_msg_connection::SmplMsgConne
 
 void SimpleCommsFaultHandler::connectionFailCB()
 {
-
   if (!(this->getConnection()->isConnected()))
   {
     LOG_INFO("Connection failed, attempting reconnect");
@@ -84,11 +82,5 @@ void SimpleCommsFaultHandler::connectionFailCB()
   }
 }
 
-
-
 }//namespace default_comms_fault_handler
 }//namespace industrial
-
-
-
-

--- a/simple_message/src/simple_message.cpp
+++ b/simple_message/src/simple_message.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -58,8 +58,6 @@ SimpleMessage::~SimpleMessage(void)
 {
 }
 
-
-
 bool SimpleMessage::init(int msgType, int commType, int replyCode)
 {
   ByteArray data;
@@ -67,7 +65,7 @@ bool SimpleMessage::init(int msgType, int commType, int replyCode)
   return this->init(msgType, commType, replyCode, data);
 }
 
-bool SimpleMessage::init(int msgType, int commType, int replyCode, ByteArray & data )
+bool SimpleMessage::init(int msgType, int commType, int replyCode, const ByteArray& data)
 {
   LOG_COMM("SimpleMessage::init(type: %d, comm: %d, reply: %d, data[%d]...)",
             msgType, commType, replyCode, data.getBufferSize());
@@ -79,7 +77,7 @@ bool SimpleMessage::init(int msgType, int commType, int replyCode, ByteArray & d
   return this->validateMessage();
 }
 
-bool SimpleMessage::init(ByteArray & msg)
+bool SimpleMessage::init(ByteArray& msg)
 {
   int dataSize = 0;
   bool rtn = false;
@@ -110,7 +108,7 @@ bool SimpleMessage::init(ByteArray & msg)
   return rtn;
 }
 
-void SimpleMessage::toByteArray(ByteArray & msg)
+void SimpleMessage::toByteArray(ByteArray& msg)
 {
   msg.init();
 
@@ -124,16 +122,13 @@ void SimpleMessage::toByteArray(ByteArray & msg)
 
 }
 
-
-void SimpleMessage::setData( ByteArray & data)
+void SimpleMessage::setData(const ByteArray& data)
 {
   this->data_.copyFrom(data);
 }
 
-
-bool SimpleMessage::validateMessage()
+bool SimpleMessage::validateMessage() const
 {
-
   if ( StandardMsgTypes::INVALID == this->getMessageType())
   {
     LOG_WARN("Invalid message type: %u", this->getMessageType());
@@ -162,7 +157,5 @@ bool SimpleMessage::validateMessage()
 }
 
 
-
-	
 } // namespace simple_message
 } // namespace industrial

--- a/simple_message/src/smpl_msg_connection.cpp
+++ b/simple_message/src/smpl_msg_connection.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -125,7 +125,7 @@ bool SmplMsgConnection::receiveMsg(SimpleMessage & message)
 
 
 bool SmplMsgConnection::sendAndReceiveMsg(SimpleMessage & send, SimpleMessage & recv, bool verbose)
-{	
+{
   bool rtn = false;
   rtn = this->sendMsg(send);
   if (rtn)

--- a/simple_message/src/socket/simple_socket.cpp
+++ b/simple_message/src/socket/simple_socket.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Yaskawa America, Inc.
@@ -71,14 +71,12 @@ namespace industrial
             rtn = false;
             logSocketError("Socket sendBytes failed", rc, errno);
           }
-
         }
         else
         {
           LOG_ERROR("Buffer size: %u, is greater than max socket size: %u", buffer.getBufferSize(), this->MAX_BUFFER_SIZE);
           rtn = false;
         }
-
       }
       else
       {
@@ -131,14 +129,14 @@ namespace industrial
               if (this->SOCKET_FAIL == rc)
               {
                 this->logSocketError("Socket received failed", rc, errno);
-		        remainBytes = 0;
+                remainBytes = 0;
                 rtn = false;
                 break;
               }
               else if (0 == rc)
               {
                 LOG_WARN("Recieved zero bytes: %u", rc);
-		        remainBytes = 0;
+                remainBytes = 0;
                 rtn = false;
                 break;
               }
@@ -185,4 +183,3 @@ namespace industrial
 
   }  //simple_socket
 }  //industrial
-

--- a/simple_message/src/socket/tcp_client.cpp
+++ b/simple_message/src/socket/tcp_client.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute

--- a/simple_message/src/socket/tcp_server.cpp
+++ b/simple_message/src/socket/tcp_server.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -166,4 +166,3 @@ bool TcpServer::makeConnect()
 
 } //tcp_socket
 } //industrial
-

--- a/simple_message/src/socket/tcp_socket.cpp
+++ b/simple_message/src/socket/tcp_socket.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Southwest Research Institute
@@ -67,16 +67,16 @@ int TcpSocket::rawSendBytes(char *buffer, shared_int num_bytes)
   int rc = this->SOCKET_FAIL;
 
   rc = SEND(this->getSockHandle(), buffer, num_bytes, 0);
-  
+
   return rc;
 }
 
 int TcpSocket::rawReceiveBytes(char *buffer, shared_int num_bytes)
 {
   int rc = this->SOCKET_FAIL;
-  
+
   rc = RECV(this->getSockHandle(), buffer, num_bytes, 0);
-  
+
   return rc;
 }
 
@@ -128,4 +128,3 @@ bool TcpSocket::rawPoll(int timeout, bool & ready, bool & error)
 
 } //tcp_socket
 } //industrial
-

--- a/simple_message/src/socket/udp_client.cpp
+++ b/simple_message/src/socket/udp_client.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Yaskawa America, Inc.
@@ -113,12 +113,12 @@ bool UdpClient::makeConnect()
   bool rtn = false;
   const int timeout = 1000;  // Time (ms) between handshake sends
   int bytesRcvd = 0;
-  
+
   if (!this->isConnected())
   {
     this->setConnected(false);
     send.load((void*)&sendHS, sizeof(sendHS));
-  
+
     // copy to local array, since ByteArray no longer supports
     // direct pointer-access to data values
     const int sendLen = send.getBufferSize();
@@ -134,7 +134,7 @@ bool UdpClient::makeConnect()
       if (this->isReadyReceive(timeout))
       {
         bytesRcvd = this->rawReceiveBytes(this->buffer_, 0);
- 	LOG_DEBUG("UDP client received possible handshake");	
+        LOG_DEBUG("UDP client received possible handshake");
         recv.init(&this->buffer_[0], bytesRcvd);
         recv.unload((void*)&recvHS, sizeof(recvHS));
       }
@@ -143,7 +143,6 @@ bool UdpClient::makeConnect()
     LOG_INFO("UDP client connected");
     rtn = true;
     this->setConnected(true);
-    
   }
   else
   {

--- a/simple_message/src/socket/udp_server.cpp
+++ b/simple_message/src/socket/udp_server.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Yaskawa America, Inc.
@@ -166,4 +166,3 @@ bool UdpServer::makeConnect()
 
 } //udp_server
 } //industrial
-

--- a/simple_message/src/socket/udp_socket.cpp
+++ b/simple_message/src/socket/udp_socket.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Software License Agreement (BSD License)
  *
  * Copyright (c) 2011, Yaskawa America, Inc.
@@ -157,4 +157,3 @@ bool UdpSocket::rawPoll(int timeout, bool & ready, bool & error)
 
 } //udp_socket
 } //industrial
-


### PR DESCRIPTION
* Fix several issues in simple_message (e.g. constness correctness, ros logging, etc.).
* The previous simple_message implementation requires the downstream users to define macros like LINUXSOCKETS ROS to make it compiled. Fix the problem by adding a cmake generated config header.

---

TBD:
* Decouple ros from `simple message`
  * ros-related code
  * cmake without using ament_cmake
* log management for `simple message` without ros